### PR TITLE
ci(actions): nix-quick-install に max-jobs = auto を設定

### DIFF
--- a/.github/actions/setup-nix-quick-cachix/action.yaml
+++ b/.github/actions/setup-nix-quick-cachix/action.yaml
@@ -14,6 +14,8 @@ runs:
       uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
       with:
         github_access_token: ${{ inputs.nix-access-token || github.token }}
+        nix_conf: |
+          max-jobs = auto
 
     - name: Setup Cachix (yasunori)
       uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17

--- a/.github/actions/setup-nix-quick/action.yaml
+++ b/.github/actions/setup-nix-quick/action.yaml
@@ -11,3 +11,5 @@ runs:
       uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
       with:
         github_access_token: ${{ inputs.nix-access-token || github.token }}
+        nix_conf: |
+          max-jobs = auto


### PR DESCRIPTION
## 概要

`nixbuild/nix-quick-install-action` を使う composite action に `max-jobs = auto` を設定し、CI のビルドが逐次実行になっていた問題を解消する。

## 変更内容

- `.github/actions/setup-nix-quick/action.yaml` に `nix_conf: max-jobs = auto` を追加
- `.github/actions/setup-nix-quick-cachix/action.yaml` に同上を追加
- 理由が後から追えるよう、両ファイルに経緯のコメントを付与

## 変更の背景・理由

上流の実装を確認して裏取りした結果、指摘のとおりだった。

- `nix-quick-install-action` の `nix-quick-install.sh` が nix.conf に書き込むのは `access-tokens` / `extra-experimental-features` / `accept-flake-config` のみで、**`max-jobs` を一切設定しない**
- Nix の `max-jobs` 既定値は **`1`**（[Nix 2.34 Reference Manual](https://nix.dev/manual/nix/2.34/command-ref/conf-file.html)）。設定が無ければ既定の 1 が適用され、ローカルビルドが 1 並列に制限される
- 対照的に `cachix/install-nix-action` は `install-nix.sh` 内で `add_config "max-jobs = auto"`（`# Set jobs to number of cores`）を明示設定している

つまり `install-nix-action` から `nix-quick-install-action` へ移行すると、この差分が黙って持ち込まれる。本リポジトリの CI は全ジョブが `nix-quick-install-action` 経由のため、`nix build` が 1 並列で動いていた。

## 動作確認

- 両 action.yaml が YAML として妥当であること、および `nix_conf` が上流 action の入力名と一致していることを `yq` で確認（入力名を誤ると Actions 側で警告なく無視されるため）
- `nix_conf` は nix.conf を上書きするが、上流スクリプトは `access-tokens` などを**その後に追記**する実装のため、トークン設定・flake 有効化を壊さないことをスクリプト本文で確認済み
- 実際の並列度は、マージ後の CI 実行ログ（ビルドの同時実行状況）で確認する想定

## 影響範囲・注意点

- 影響は CI のみ。パッケージ定義・lib・モジュールの成果物には変更なし
- 対象は `Test` / `Cachix Push` 両ワークフローの全ジョブ（両 composite action 経由のため）
- `auto` はランナーのコア数を使う。GitHub ホストランナーのコア数上限内であり、メモリ逼迫が起きる場合は `max-jobs` を固定値に変更する余地がある
